### PR TITLE
Remove '-s' and '--'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
-  - '7'
+  - '8'
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
 cache: yarn
 script: yarn test -- --runInBand --coverage && yarn flow

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ type RunOptions = {
 */
 
 exports.run = (opts /*: RunOptions */) => {
-  let args = ['run', opts.name, '-s', '--'];
+  let args = ['run', opts.name];
 
   if (opts.flags) {
     args = args.concat(opts.flags);


### PR DESCRIPTION
Yarn 1 outputs the following warning:
```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```